### PR TITLE
Require explicit type casts for returned void * due to inclusion in a…

### DIFF
--- a/src/openssl/x509.c
+++ b/src/openssl/x509.c
@@ -1852,7 +1852,7 @@ xmlSecOpenSSLX509NameWrite(X509_NAME* nm) {
     (void)BIO_flush(mem); /* should call flush ? */
 
     size = BIO_pending(mem);
-    res = xmlMalloc(size + 1);
+    res = (xmlChar *)xmlMalloc(size + 1);
     if(res == NULL) {
         xmlSecMallocError(size + 1, NULL);
         BIO_free_all(mem);
@@ -1925,7 +1925,7 @@ xmlSecOpenSSLX509SKIWrite(X509* cert) {
         return(NULL);
     }
 
-    keyId = X509V3_EXT_d2i(ext);
+    keyId = (ASN1_OCTET_STRING *)X509V3_EXT_d2i(ext);
     if (keyId == NULL) {
         xmlSecOpenSSLError("X509V3_EXT_d2i", NULL);
         ASN1_OCTET_STRING_free(keyId);

--- a/src/openssl/x509vfy.c
+++ b/src/openssl/x509vfy.c
@@ -671,7 +671,7 @@ xmlSecOpenSSLX509VerifyCRL(X509_STORE* xst, X509_CRL *crl ) {
         xmlSecOpenSSLError("X509_STORE_CTX_new", NULL);
         goto err;
     }
-    xobj = X509_OBJECT_new();
+    xobj = (X509_OBJECT *)X509_OBJECT_new();
     if(xobj == NULL) {
         xmlSecOpenSSLError("X509_OBJECT_new", NULL);
         goto err;
@@ -806,7 +806,7 @@ xmlSecOpenSSLX509FindCert(STACK_OF(X509) *certs, xmlChar *subjectName,
             cert = sk_X509_value(certs, i);
             index = X509_get_ext_by_NID(cert, NID_subject_key_identifier, -1);
             if((index >= 0)  && (ext = X509_get_ext(cert, index))) {
-                keyId = X509V3_EXT_d2i(ext);
+                keyId = (ASN1_OCTET_STRING *)X509V3_EXT_d2i(ext);
                 if((keyId != NULL) && (keyId->length == len) &&
                                     (memcmp(keyId->data, ski, len) == 0)) {
                     ASN1_OCTET_STRING_free(keyId);

--- a/src/relationship.c
+++ b/src/relationship.c
@@ -299,7 +299,7 @@ xmlSecTransformRelationshipProcessNode(xmlSecTransformPtr transform, xmlOutputBu
 
         ctx = xmlSecRelationshipGetCtx(transform);
         for(ii = 0; ii < xmlSecPtrListGetSize(ctx->sourceIdList); ++ii) {
-            if(xmlStrcmp(xmlSecPtrListGetItem(ctx->sourceIdList, ii), id) == 0) {
+            if(xmlStrcmp((xmlChar *)xmlSecPtrListGetItem(ctx->sourceIdList, ii), id) == 0) {
                 found = 1;
                 break;
             }

--- a/src/xmltree.c
+++ b/src/xmltree.c
@@ -896,7 +896,7 @@ xmlSecGetQName(xmlNodePtr node, const xmlChar* href, const xmlChar* local) {
         xmlSecSize len;
 
         len = xmlStrlen(local) + xmlStrlen(ns->prefix) + 4;
-        qname = xmlMalloc(len);
+        qname = (xmlChar *)xmlMalloc(len);
         if(qname == NULL) {
             xmlSecMallocError(len, NULL);
             return(NULL);


### PR DESCRIPTION
…n XCode project that forces compilation with cross support for various C and C++ dialects (#177)